### PR TITLE
Send alerts in Discord's rich embed format

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,8 @@ type alertManOut struct {
 }
 
 type discordOut struct {
-	Embeds []discordEmbed `json:"embeds"`
+	Content string         `json:"content"`
+	Embeds  []discordEmbed `json:"embeds"`
 }
 
 type discordEmbed struct {
@@ -97,7 +98,7 @@ func main() {
 			DO := discordOut{}
 
 			RichEmbed := discordEmbed{
-				Title:       amo.CommonLabels.Alertname,
+				Title:       fmt.Sprintf("[%s:%d] %s", strings.ToUpper(status), len(alerts), amo.CommonLabels.Alertname),
 				Description: amo.CommonAnnotations.Summary,
 				Color:       ColorGrey,
 				Fields:      []discordEmbedField{},
@@ -107,6 +108,10 @@ func main() {
 				RichEmbed.Color = ColorRed
 			} else if status == "resolved" {
 				RichEmbed.Color = ColorGreen
+			}
+
+			if amo.CommonAnnotations.Summary != "" {
+				DO.Content = fmt.Sprintf(" === %s === \n", amo.CommonAnnotations.Summary)
 			}
 
 			for _, alert := range alerts {


### PR DESCRIPTION
We can send [rich embeds to Discord](https://discord.com/developers/docs/resources/channel#embed-object) instead of plain text. This seems ideal for our case as we can add hints like color etc. to make the alerts visually differentiable.

#### Original:
![image](https://user-images.githubusercontent.com/29674758/87880980-bfd7c600-ca13-11ea-9ee4-b96d1b8e35c8.png)

#### With rich embed:
##### Firing:
![image](https://user-images.githubusercontent.com/29674758/87880996-e695fc80-ca13-11ea-9516-dac693c6620e.png)

##### Resolved:
![image](https://user-images.githubusercontent.com/29674758/87881004-f6addc00-ca13-11ea-879d-606752a49538.png)
