### PR TITLE
Add listen.address as a CLI parameter and check WebHook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ COPY --from=builder /go/bin/alertmanager-discord /go/bin/alertmanager-discord
 
 EXPOSE 9094
 USER appuser
-ENTRYPOINT ["/go/bin/alertmanager-discord"]
+ENTRYPOINT ["/go/bin/alertmanager-discord", "-listen.address", "0.0.0.0:9094"]
 

--- a/main.go
+++ b/main.go
@@ -67,14 +67,23 @@ type discordEmbedField struct {
 	Value string `json:"value"`
 }
 
+const defaultListenAddress = "127.0.0.1:9094"
+
 func main() {
 	envWhURL := os.Getenv("DISCORD_WEBHOOK")
 	whURL := flag.String("webhook.url", envWhURL, "Discord WebHook URL.")
-	listenAddress := flag.String("listen.address", "127.0.0.1:9094", "Address:Port to listen on.")
+
+	envListenAddress := os.Getenv("LISTEN_ADDRESS")
+	listenAddress := flag.String("listen.address", envListenAddress, "Address:Port to listen on.")
+
 	flag.Parse()
 
 	if *whURL == "" {
 		log.Fatalf("Environment variable 'DISCORD_WEBHOOK' or CLI parameter 'webhook.url' not found.")
+	}
+
+	if *listenAddress == "" {
+		*listenAddress = defaultListenAddress
 	}
 
 	re := regexp.MustCompile(`https://discord(?:app)?.com/api/webhooks/[0-9]{18}/[a-zA-Z0-9_-]+`)


### PR DESCRIPTION
Allow to customize the listening address and port with a CLI parameter.

We are limited to one Discord Webhook per running daemon. With this parameter we can run multiple daemon on differents ports if needed (to send alerts to various Discord Channels).

I also added a REGEX check on the Discord WebHook.