### PR TITLE
Removed GOARCH parameter to be able to build arm images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR $GOPATH/src/mypackage/myapp/
 #get dependancies
 RUN go get -d -v
 #build the binary
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/alertmanager-discord
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/alertmanager-discord
 
 
 # STEP 2 build a small image
@@ -26,4 +26,3 @@ ENV LISTEN_ADDRESS=0.0.0.0:9094
 EXPOSE 9094
 USER appuser
 ENTRYPOINT ["/go/bin/alertmanager-discord"]
-


### PR DESCRIPTION
Hi, 

I have a nomad based cluster with a lot of arm devices. To be able to run your image on those I removed the GOARCH parameter from the Dockerfile and builded the images using [buildx](https://docs.docker.com/buildx/working-with-buildx/);

```
$ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
$ docker buildx build -t benjojo/alertmanager-discord:latest --platform linux/amd64,linux/arm/v6,linux/arm/v7 --push .
```

by building this way you still have one tag available latest but available with multiple architectures as you can see on my [docker hub](https://hub.docker.com/repository/docker/visibilityspots/alertmanager-discord/tags). As soon as you have those architectures available I'll remove those images!

You could perhaps consider to create a github workflow like I did for a [cloudflared](https://github.com/visibilityspots/dockerfile-cloudflared/blob/master/.github/workflows/main.yml) image. That way the image is rebuild every week with a potential new alpine base container..