### PR TITLE
Add circleci and pre-commit

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+DOCKER_IMAGE_TAG=speckle/alertmanager-discord
+export DOCKER_BUILDKIT=1
+
+docker build --tag "${DOCKER_IMAGE_TAG}:${CIRCLE_SHA1}.${CIRCLE_BUILD_NUM}" --file ./Dockerfile .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,89 @@
+version: 2.1
+
+workflows:
+  version: 2
+  build-image:
+    jobs:
+      # - pre-commit:
+      #     filters:
+      #       tags: &filter-all-tags # run for all tags
+      #         only: /.*/
+
+      - docker-build:
+          filters:
+            tags: *filter-all-tags
+            branches:
+              ignore:
+                - main
+
+      - docker-build-and-publish:
+          context:
+            - docker-hub
+          filters:
+            tags: *filter-all-tags
+            branches:
+              only:
+                - main
+
+jobs:
+  # pre-commit:
+  #   parameters:
+  #     config_file:
+  #       default: ./.pre-commit-config.yaml
+  #       description: Optional, path to pre-commit config file.
+  #       type: string
+  #     cache_prefix:
+  #       default: ""
+  #       description: |
+  #         Optional cache prefix to be used on CircleCI. Can be used for cache busting or to ensure multiple jobs use different caches.
+  #       type: string
+  #   docker:
+  #     - image: speckle/pre-commit-runner:latest
+  #   resource_class: large
+  #   working_directory: &workingdir /tmp/ci
+  #   steps:
+  #     - checkout
+  #     - restore_cache:
+  #         keys:
+  #           - cache-pre-commit-<<parameters.cache_prefix>>-{{ checksum "<<parameters.config_file>>" }}
+  #     - run:
+  #         name: Install pre-commit hooks
+  #         command: pre-commit install-hooks --config <<parameters.config_file>>
+  #     - save_cache:
+  #         key: cache-pre-commit-<<parameters.cache_prefix>>-{{ checksum "<<parameters.config_file>>" }}
+  #         paths:
+  #           - ~/.cache/pre-commit
+  #     - run:
+  #         name: Run pre-commit
+  #         command: pre-commit run --all-files --config <<parameters.config_file>>
+  #     - run:
+  #         command: git --no-pager diff
+  #         name: git diff
+  #         when: on_fail
+
+  docker-build-and-publish:
+    docker: &docker-image
+      - image: cimg/base:2022.04
+    resource_class: &docker-resource-class large
+    working_directory: *workingdir
+    steps:
+      - checkout
+      - setup_remote_docker: &remote-docker
+          # a weird issue with yarn installing packages throwing EPERM errors
+          # this fixes it
+          version: 20.10.12
+          docker_layer_caching: true
+      - run:
+          name: Build and Publish
+          command: ./.circleci/build.sh && ./.circleci/publish.sh
+
+  docker-build:
+    docker: *docker-image
+    resource_class: *docker-resource-class
+    working_directory: *workingdir
+    steps:
+      - checkout
+      - setup_remote_docker: *remote-docker
+      - run:
+          name: Build
+          command: ./.circleci/build.sh

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+DOCKER_IMAGE_TAG=speckle/alertmanager-discord
+
+docker tag "${DOCKER_IMAGE_TAG}:${CIRCLE_SHA1}.${CIRCLE_BUILD_NUM}" "${DOCKER_IMAGE_TAG}:latest"
+
+echo "${DOCKER_REG_PASS}" | docker login -u "${DOCKER_REG_USER}" --password-stdin "${DOCKER_REG_URL}"
+docker push -a "${DOCKER_IMAGE_TAG}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,46 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.0.0-alpha.4" # Use the sha / tag you want to point at
+    hooks:
+      - id: prettier
+
+  - repo: https://github.com/hadolint/hadolint
+    rev: "v2.10.0"
+    hooks:
+      - id: hadolint
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: "v4.3.0"
+    hooks:
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: check-vcs-permalinks
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/syntaqx/git-hooks
+    rev: "v0.0.17"
+    hooks:
+      - id: circleci-config-validate
+
+  - repo: https://github.com/Jarmos-san/shellcheck-precommit
+    rev: "v0.2.0"
+    hooks:
+      - id: shellcheck-system
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: "v0.5.1"
+    hooks:
+      - id: go-fmt
+      - id: go-vet
+      - id: no-go-testing
+      - id: go-critic
+      - id: go-unit-tests
+      - id: go-build
+      - id: go-mod-tidy
+
+ci:
+  autoupdate_schedule: quarterly

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,17 @@
 # STEP 1 build executable binary
 FROM golang:alpine as builder
 # Install SSL ca certificates
-RUN apk update && apk add git && apk add ca-certificates
+RUN apk update && apk add --no-cache \
+  git=2.36.3-r0 \
+  ca-certificates=20220614-r0
 # Create appuser
 RUN adduser -D -g '' appuser
 COPY . $GOPATH/src/mypackage/myapp/
 WORKDIR $GOPATH/src/mypackage/myapp/
 #get dependancies
-RUN go get -d -v
-#build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/alertmanager-discord
+RUN go get -d -v \
+    # build the binary
+    && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags="-w -s" -o /go/bin/alertmanager-discord
 
 
 # STEP 2 build a small image
@@ -20,9 +22,9 @@ FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/passwd /etc/passwd
 # Copy our static executable
-COPY --from=builder /go/bin/alertmanager-discord /go/bin/alertmanager-discord
+COPY --from=builder /go/bin/alertmanager-discord /bin/alertmanager-discord
 
 ENV LISTEN_ADDRESS=0.0.0.0:9094
 EXPOSE 9094
 USER appuser
-ENTRYPOINT ["/go/bin/alertmanager-discord"]
+ENTRYPOINT ["/bin/alertmanager-discord"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-alertmanager-discord
-===
+# alertmanager-discord
 
 Give this a webhook (with the DISCORD_WEBHOOK environment variable) and point it as a webhook on alertmanager, and it will post your alerts into a discord channel for you as they trigger:
 
@@ -14,11 +13,11 @@ The standard "dataflow" should be:
 ```
 Prometheus -------------> alertmanager -------------------> alertmanager-discord
 
-alerting:                 receivers:                         
+alerting:                 receivers:
   alertmanagers:          - name: 'discord_webhook'         environment:
   - static_configs:         webhook_configs:                   - DISCORD_WEBHOOK=https://discordapp.com/api/we...
-    - targets:              - url: 'http://localhost:9094'  
-       - 127.0.0.1:9093   
+    - targets:              - url: 'http://localhost:9094'
+       - 127.0.0.1:9093
 
 
 
@@ -37,7 +36,7 @@ global:
   smtp_auth_password: 'password'
 
 # The directory from which notification templates are read.
-templates: 
+templates:
 - '/etc/alertmanager/template/*.tmpl'
 
 # The root route on which each incoming alert enters.
@@ -45,7 +44,7 @@ route:
   group_by: ['alertname']
   group_wait: 20s
   group_interval: 5m
-  repeat_interval: 3h 
+  repeat_interval: 3h
   receiver: discord_webhook
 
 receivers:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/benjojo/alertmanager-discord
 
-go 1.15
+go 1.19


### PR DESCRIPTION
- CircleCI to build on every commit
- CircleCI will publish every commit to main branch
- pre-commit script (can only be run locally with `go` installed).
- bump `go` to version `1.19`
- Fixes issues in Dockerfile and README which did not conform to standards applied via pre-commit