### PR TITLE
Add building and pushing Docker images to ghcr.io for all architectures

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -1,0 +1,54 @@
+name: Build and Publish
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  platforms: linux/amd64,linux/arm64,linux/arm/v7
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Set up Docker Build
+        uses: docker/setup-buildx-action@v2
+
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io 
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta for alertmanager-discord
+        id: alertmanager-discord-meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/alertmanager-discord
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: ${{ env.platforms }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          tags: ${{ steps.alertmanager-discord-meta.outputs.tags }}
+          labels: ${{ steps.alertmanager-discord-meta.outputs.labels }}


### PR DESCRIPTION
This PR adds automated building to the Docker image in the project and publishes it to Github Container Registry,

It builds for:

ARM64
ARMv7
AMD64